### PR TITLE
Add featured events

### DIFF
--- a/inc/acf.php
+++ b/inc/acf.php
@@ -6,6 +6,25 @@ if ( function_exists('acf_add_local_field_group') ):
 function squarecandy_events_add_fields() {
 	$eventfields = array();
 	$eventfields[] = array(
+		'key' => 'field_5d2c47ed9268c',
+		'label' => 'Feature Event',
+		'name' => 'featured',
+		'type' => 'true_false',
+		'instructions' => '',
+		'required' => 0,
+		'conditional_logic' => 0,
+		'wrapper' => array(
+			'width' => '100',
+			'class' => '',
+			'id' => '',
+		),
+		'message' => '',
+		'default_value' => 0,
+		'ui' => 0,
+		'ui_on_text' => '',
+		'ui_off_text' => '',
+	);
+	$eventfields[] = array(
 		'key' => 'field_5616bbe39fbec',
 		'label' => '(Start) Date',
 		'name' => 'start_date',

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -102,41 +102,48 @@ function squarecandy_events_func( $atts = array() ) {
 		$past = false;
 	} else {
 		// upcoming events (default)
+		$meta_query = array(
+			'relation' => 'AND',
+			array(
+				'relation' => 'OR',
+				array(
+					'key' => 'start_date',
+					'type' => 'DATE',
+					'value' => $today,
+					'compare' => '>='
+				),
+				array(
+					'key' => 'end_date',
+					'type' => 'DATE',
+					'value' => $today,
+					'compare' => '>='
+				)
+			),
+		);
+
+		if ( isset($atts['exclude_featured']) && $atts['exclude_featured'] == 'true' ) {
+			$exclude_featured = array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'featured',
+					'value'   => 0,
+					'compare' => '='
+				),
+				array(
+					'key'     => 'featured',
+					'compare' => 'NOT EXISTS'
+				)
+			);
+
+			array_push( $meta_query, $exclude_featured );
+		}
+
 		$args = array(
 			'post_type' => 'event',
 			'post_status' => 'publish',
 			'posts_per_page' => -1,
 			'orderby' => $orderby,
-			'meta_query' => array(
-				'relation' => 'AND',
-				array(
-					'relation' => 'OR',
-					array(
-						'key' => 'start_date',
-						'type' => 'DATE',
-						'value' => $today,
-						'compare' => '>='
-					),
-					array(
-						'key' => 'end_date',
-						'type' => 'DATE',
-						'value' => $today,
-						'compare' => '>='
-					)
-				),
-				array(
-					'relation' => 'OR',
-					array(
-						'key'     => 'featured',
-						'value'   => 0,
-						'compare' => '='
-					),
-					array(
-						'key'     => 'featured',
-						'compare' => 'NOT EXISTS'
-					)
-				)
-			),
+			'meta_query' => $meta_query,
 		);
 		$past = false;
 	}


### PR DESCRIPTION
This commit adds featured events to the plugin.

Here's a summary of what this means:
1. Events now have a new true/false field called "Feature Event".
2. `[squarecandy_events type=featured]` will only show upcoming featured events.
3. `[squarecandy_events]` does not show featured events.

With regards to point 3, I don't know if that's the best option. On The Foundry, we need to be able to display all upcoming events that are not featured. 

Maybe adding a shortcode attribute called `exclude_featured` would be a better approach. 

What are your thoughts @squarecandy?